### PR TITLE
Add link to a code component's image build URL

### DIFF
--- a/plugins/visual-qontract/src/components/CodeComponentsComponent/CodeComponentsComponent.tsx
+++ b/plugins/visual-qontract/src/components/CodeComponentsComponent/CodeComponentsComponent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {
+
     Typography,
-    Grid,
+    IconButton,
     Link,
     Table,
     TableContainer,
@@ -11,11 +12,14 @@ import {
     TableCell,
     Paper
 } from '@material-ui/core';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import NotListedLocationIcon from '@material-ui/icons/NotListedLocation'
 import {
     InfoCard,
 } from '@backstage/core-components';
 import { CodeComponentsQuery } from './query';
 import QueryQontract from '../../common/QueryAppInterface';
+
 
 export const CodeComponentsComponent = () => {
 
@@ -24,20 +28,29 @@ export const CodeComponentsComponent = () => {
     const title = "Code Repositories"
 
     const CodeComponentsTable = () => {
-        return  <TableContainer component={Paper} >
-                <Table size="small" >
+        return  <TableContainer component={Paper}>
+                <Table size="small">
                     <TableHead>
                         <TableRow>
                             <TableCell><Typography variant="button">Name</Typography></TableCell>
+                            <TableCell align="center"><Typography variant="button">Build Job</Typography></TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {result.apps_v1[0].codeComponents.map((component: any, key: any) => (
                             <TableRow key={key}>
-                                <TableCell>
+                                <TableCell scope="row">
                                     <Link target="_blank" href={component.url}>
                                         {component.name}
                                     </Link>
+                                </TableCell>
+                                <TableCell align="center">
+                                    <IconButton aria-label="go-to-build-job" size="small">
+                                        {component.imageBuildUrl
+                                            ? <Link target="_blank" href={component.imageBuildUrl}><ExitToAppIcon /></Link>
+                                            : <NotListedLocationIcon />
+                                        }
+                                    </IconButton>
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/plugins/visual-qontract/src/components/CodeComponentsComponent/query.tsx
+++ b/plugins/visual-qontract/src/components/CodeComponentsComponent/query.tsx
@@ -8,6 +8,7 @@ query App($path: String) {
       name
       resource
       url
+      imageBuildUrl
     }
   }
 }

--- a/plugins/visual-qontract/src/components/PipelinesComponent/PipelinesComponent.tsx
+++ b/plugins/visual-qontract/src/components/PipelinesComponent/PipelinesComponent.tsx
@@ -73,7 +73,7 @@ export const PipelinesComponent = () => {
     return (
       <Grid>
         <Grid item>
-          <Typography variant="overline">SaSS File</Typography>
+          <Typography variant="overline">SaaS File</Typography>
         </Grid>
         <Grid item>
           <Link target="_blank" href={getAppInterfaceLink(path)}>


### PR DESCRIPTION
Links out to a code component's `imageBuildUrl` if found. Happy to change the styling/icons being used here if we think something else from the material v4 icon set works better.