### PR TITLE
Use 'visual-qontract/app-path' annotation if defined on an entity

### DIFF
--- a/plugins/visual-qontract/src/common/QueryAppInterface.ts
+++ b/plugins/visual-qontract/src/common/QueryAppInterface.ts
@@ -20,6 +20,14 @@ const QueryQontract = (query: string) => {
 
     // Function to get the app interface path
     const getQontractPath = () => {
+        // use 'visual-qontract/app-path' annotation if defined on the entity
+        if (entity?.metadata?.annotations !== undefined) {
+            if ("visual-qontract/app-path" in entity.metadata.annotations) {
+                return entity.metadata.annotations["visual-qontract/app-path"]
+            }
+        }
+
+        // otherwise fall back to making an educated guess at this entity's app path
         const platform = entity?.metadata?.labels?.platform
         const service = entity?.metadata?.labels?.service
         return `/services/${platform}/${service}/app.yml`

--- a/plugins/visual-qontract/src/common/QueryAppInterface.ts
+++ b/plugins/visual-qontract/src/common/QueryAppInterface.ts
@@ -21,10 +21,9 @@ const QueryQontract = (query: string) => {
     // Function to get the app interface path
     const getQontractPath = () => {
         // use 'visual-qontract/app-path' annotation if defined on the entity
-        if (entity?.metadata?.annotations !== undefined) {
-            if ("visual-qontract/app-path" in entity.metadata.annotations) {
-                return entity.metadata.annotations["visual-qontract/app-path"]
-            }
+        const appPath = entity?.metadata?.annotations?.["visual-qontract/app-path"];
+        if (appPath) {
+             return appPath
         }
 
         // otherwise fall back to making an educated guess at this entity's app path


### PR DESCRIPTION
Instead of making an educated guess at a component's app path in app-interface, we will use an annotation named `visual-qontract/app-path`. If this annotation is not found to be defined on the entity we fall back to the "existing method"