### PR TITLE
Support Multiple email recipients

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -159,13 +159,11 @@ const overviewContent = (
     <Grid item md={6}>
       <EntityQontractPipelinesComponent />
     </Grid>
-
     <Grid item md={6}>
       <EntityQontractSLOComponent />
     </Grid>
     <Grid item md={6}>
       <EntityQontractEscalationPolicyComponent />
-
     </Grid>
   </Grid>
 );

--- a/plugins/visual-qontract/package.json
+++ b/plugins/visual-qontract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-visual-qontract",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/visual-qontract/src/components/EscalationPolicyComponent/EscalationPolicyComponent.tsx
+++ b/plugins/visual-qontract/src/components/EscalationPolicyComponent/EscalationPolicyComponent.tsx
@@ -98,7 +98,7 @@ export const EscalationPolicyComponent = () => {
 
   return (
     <InfoCard title={title} noPadding>
-      <Grid container spacing={2} direction="column">
+      <Grid container spacing={3} direction="column">
         <Grid item>
           <NextEscalationPolicyRow ep={result.apps_v1[0].escalationPolicy}  />
           {escalationPolicies.map((component: any, key: any) => (

--- a/plugins/visual-qontract/src/components/EscalationPolicyComponent/EscalationPolicyComponent.tsx
+++ b/plugins/visual-qontract/src/components/EscalationPolicyComponent/EscalationPolicyComponent.tsx
@@ -71,7 +71,6 @@ export const EscalationPolicyComponent = () => {
 
 
   if (error || requestError) {
-    debugger;
     return (
       <InfoCard title={title}>
         <Typography align="center" variant="body1">
@@ -99,7 +98,7 @@ export const EscalationPolicyComponent = () => {
 
   return (
     <InfoCard title={title} noPadding>
-      <Grid container spacing={3} direction="column">
+      <Grid container spacing={2} direction="column">
         <Grid item>
           <NextEscalationPolicyRow ep={result.apps_v1[0].escalationPolicy}  />
           {escalationPolicies.map((component: any, key: any) => (

--- a/plugins/visual-qontract/src/components/EscalationPolicyComponent/NextEscalationPolicyRow.tsx
+++ b/plugins/visual-qontract/src/components/EscalationPolicyComponent/NextEscalationPolicyRow.tsx
@@ -60,7 +60,7 @@ export const NextEscalationPolicyRow = ({ ep }: { ep: any }) => {
           <Typography variant="button">{ep.name}</Typography>
         </Grid>
         <Grid item xs={4}>
-          {email && < ContactItem channel='email' href={"mailto:" + email} text={email} />}
+          {email && < ContactItem channel='email' href={"mailto:" + email.join(',')} text={email.join('\n')} />}
         </Grid>
         <Grid item xs={4}>
           {slack.path && slack.name && < ContactItem channel='Slack' href={getAppInterfaceLink(slack.path)} text={slack.name} />}


### PR DESCRIPTION
Currently escalation policies with multiple emails listed don't work. The emails get mashed together.
This PR supports multiple emails now, allowing for single or multiple recipients.