### PR TITLE
Add better error handling to incident card

### DIFF
--- a/plugins/visual-qontract/package.json
+++ b/plugins/visual-qontract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-visual-qontract",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.test.tsx
+++ b/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.test.tsx
@@ -45,7 +45,7 @@ const mockFailedWebRCABackendFetchApi = {
       total: 3,
       ok: true,
       code: 200,
-      items: jest
+      json: jest
         .fn()
         .mockResolvedValue({
           error: { name: 'AuthenticationError', message: 'Illegal token' },

--- a/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.test.tsx
+++ b/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.test.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  screen,
-  fireEvent,
-  waitFor,
-} from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { IncidentResponseCard } from './IncidentResponseCard';
 import { configApiRef, fetchApiRef } from '@backstage/core-plugin-api';
 import {
@@ -37,6 +33,28 @@ const mockFailedFetchApi = {
       ok: false,
       code: 500,
       items: jest.fn().mockResolvedValue({}),
+    }),
+  }),
+};
+
+const mockFailedWebRCABackendFetchApi = {
+  fetch: jest.fn().mockResolvedValue({
+    ok: false,
+    json: jest.fn().mockResolvedValue({
+      kind: 'response',
+      total: 3,
+      ok: true,
+      code: 200,
+      items: jest
+        .fn()
+        .mockResolvedValue({
+          error: { name: 'AuthenticationError', message: 'Illegal token' },
+          request: {
+            method: 'GET',
+            url: '/api/proxy/web-rca/incidents?status=ongoing&invalid=false&public=true&order_by=created_at%20desc',
+          },
+          response: { statusCode: 401 },
+        }),
     }),
   }),
 };
@@ -96,7 +114,6 @@ describe('<IncidentResponseCard />', () => {
       expect(screen.getByText('Incident 1')).toBeInTheDocument();
       expect(screen.getByText('Incident 2')).toBeInTheDocument();
       expect(screen.getByText('Incident 3')).toBeInTheDocument();
-
     });
   });
 
@@ -106,6 +123,24 @@ describe('<IncidentResponseCard />', () => {
         apis={[
           [configApiRef, mockConfigApi],
           [fetchApiRef, mockFailedFetchApi],
+        ]}
+      >
+        <IncidentResponseCard />
+      </TestApiProvider>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/An error occurred while fetching incidents/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('displays error message if talking to webrca backend fails ', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [configApiRef, mockConfigApi],
+          [fetchApiRef, mockFailedWebRCABackendFetchApi],
         ]}
       >
         <IncidentResponseCard />

--- a/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.tsx
+++ b/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.tsx
@@ -47,7 +47,7 @@ export const IncidentResponseCard = () => {
         )}/api/plugin-web-rca-backend/incidents/public`,
       );
 
-      if (!response.ok) {
+      if (!response.ok ) {
         throw new Error(
           `Network response was not ok: ${response.status} ${response.statusText}`,
         );
@@ -55,7 +55,7 @@ export const IncidentResponseCard = () => {
 
       const json = await response.json();
 
-      if (json.kind === 'Error') {
+      if (json.kind === 'Error' || json.response.statusCode !== 200) {
         throw new Error('Something went wrong talking to WebRCA');
       }
 

--- a/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.tsx
+++ b/plugins/visual-qontract/src/components/HomeComponent/IncidentResponseCard.tsx
@@ -55,7 +55,7 @@ export const IncidentResponseCard = () => {
 
       const json = await response.json();
 
-      if (json.kind === 'Error' || json.response.statusCode !== 200) {
+      if (json.kind === 'Error' || json.error) {
         throw new Error('Something went wrong talking to WebRCA');
       }
 


### PR DESCRIPTION
We didn't handle the error thoroughly getting the incidents. Turns out you get a 200 from the proxy with JSON, but the JSON has the error it relayed from the webrca API