### PR TITLE
InScope app-interface changelog time selection improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ We also provide 3 pages that can extend the functionality of Janus IDP / RHDH.
 You'll need to have the `inscope-resources` pod running. This pod contains the resources like new stories used on the front page.
 
 Running the following script will download the images from the Quay repository and run the `inscope-resources` pod locally.
+
+> NOTE: You may need to log in to the Quay resource prior to pulling the image.
+`podman login quay`
+
 ```bash
 if ! podman container exists resources &> /dev/null; then
     echo "Starting resources container..."
@@ -56,6 +60,7 @@ data:
 ```
 
 Run the pod locally using the following script - this mounts the local `config-map.json` into the local pod to be served by the proxy.
+
 ```bash
 if ! podman container exists resources &> /dev/null; then
     echo "Starting resources container"

--- a/README.md
+++ b/README.md
@@ -29,50 +29,87 @@ We also provide 3 pages that can extend the functionality of Janus IDP / RHDH.
 ## Dependencies 
 You'll need to have the `inscope-resources` pod running. This pod contains the resources like new stories used on the front page.
 
+Running the following script will download the images from the Quay repository and run the `inscope-resources` pod locally.
+```bash
+if ! podman container exists resources &> /dev/null; then
+    echo "Starting resources container..."
+    podman pull quay.io/app-sre/inscope-resources:latest
+    podman run -d --name resources \
+        --hostname resources \
+        -p 8000:8000 \
+        quay.io/app-sre/inscope-resources:latest
+fi
+```
+
+### Changelog Development
+In order to populate the changelog locally, [download the updated changelog from Openshift](https://console-openshift-console.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com/k8s/ns/backstage-stage/configmaps/change-log/yaml).
+
+Copy the contents from the `config-map.json` field into a separate JSON file named `config-map.json` in the root of the plugin directory.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+...
+data:
+  config-map.json: '<--- COPY THIS INTO CONFIG-MAP.JSON FILE --->'
+```
+
+Run the pod locally using the following script - this mounts the local `config-map.json` into the local pod to be served by the proxy.
+```bash
+if ! podman container exists resources &> /dev/null; then
+    echo "Starting resources container"
+    podman pull quay.io/app-sre/inscope-resources:latest
+    podman run -d --name resources \
+        --hostname resources \
+        -p 8000:8000 \
+        -v $(pwd)/config-map.json:/opt/app-root/src/resources/configmap/change-log.json:Z \
+        quay.io/app-sre/inscope-resources:latest
+fi
+```
+
 ## Configuration
 In `app-config.yaml` first add the proxies:
 
 ```yaml
 proxy:
   endpoints:
-    # Used for app-interface data from a qontract server
-    '/visual-qontract': ${QONTRACT_SERVER}
-    # Used to pull metrics from prometheus for SLO cards
+    '/visual-qontract': 
+      target: 'https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/'
     '/prometheus':
-      target: ${PROMETHEUS_SERVER}
+      target: "https://prometheus.crcs02ue1.devshift.net/api/v1/"
       allowedMethods: ['POST', 'GET']
       headers:
         Authorization: "Bearer ${PROMETHEUS_TOKEN}"
-    # inscope-resources pod. This proxy ensures backwards compatibility with the RHDH home page.
     '/developer-hub':
       target: 'http://localhost:8000'
       pathRewrite:
         '^/api/proxy/developer-hub': '/resources/json/homepage.json'
       changeOrigin: true
-      secure: false
-    # inscope-resources pod. provides resources for the home page.
     '/inscope-resources':
-      target: 'http://localhost:8000'
+      target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
-    # Status page URL
+    '/inscope-resources/resources/images':
+      target: '${INSCOPE_RESOURCES_URL}'
+      changeOrigin: true
+      secure: false
+      credentials: dangerously-allow-unauthenticated
     '/status':
-      target: ${STATUS_PAGE_URL}
+      target: 'https://status.redhat.com/api/v2/summary.json'
+      changeOrigin: true
+    '/status-board':
+      target: '${STATUS_BOARD_API}'
+      allowedHeaders: ['Authorization']
+    '/sso-redhat':
+      target: '${SSO_URL}'
+      allowedHeaders: ['Content-Type']
+    '/mergeq':
+      target: 'https://gitlab.cee.redhat.com/service/app-interface-output/-/raw/master/'
       changeOrigin: true
       secure: false
-    # Web RCA API backend
-    '/web-rca':
-      target: ${WEB_RCA_API}
-      allowedHeaders: ['Authorization']
-    # Status Board API
-    '/status-board':
-      target: ${STATUS_BOARD_API}
-      allowedHeaders: ['Authorization']
-    # SSO URL for OAuth flow
-    '/sso-redhat':
-      target: ${SSO_URL}
-      allowedHeaders: ['Content-Type']
 ```
+
 ## RHDH Dynamic Plugin Config
 Here's an example of how to configure all of the various plugins in your dynmaic plugins config for RHDH.
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,11 +65,11 @@ proxy:
         '^/api/proxy/developer-hub': '/resources/json/homepage.json'
       changeOrigin: true
     '/inscope-resources':
-      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
+      target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
     '/inscope-resources/resources/images':
-      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
+      target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
       credentials: dangerously-allow-unauthenticated

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,11 +65,11 @@ proxy:
         '^/api/proxy/developer-hub': '/resources/json/homepage.json'
       changeOrigin: true
     '/inscope-resources':
-      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
+      target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
     '/inscope-resources/resources/images':
-      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
+      ;target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
       credentials: dangerously-allow-unauthenticated

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -69,7 +69,7 @@ proxy:
       changeOrigin: true
       secure: false
     '/inscope-resources/resources/images':
-      ;target: '${INSCOPE_RESOURCES_URL}'
+      target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
       credentials: dangerously-allow-unauthenticated

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -72,7 +72,6 @@ proxy:
       target: '${INSCOPE_RESOURCES_URL}'
       changeOrigin: true
       secure: false
-      credentials: dangerously-allow-unauthenticated
     '/status':
       target: 'https://status.redhat.com/api/v2/summary.json'
       changeOrigin: true

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,11 +65,11 @@ proxy:
         '^/api/proxy/developer-hub': '/resources/json/homepage.json'
       changeOrigin: true
     '/inscope-resources':
-      target: '${INSCOPE_RESOURCES_URL}'
+      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
       changeOrigin: true
       secure: false
     '/inscope-resources/resources/images':
-      target: '${INSCOPE_RESOURCES_URL}'
+      target: 'https://inscope.corp.stage.redhat.com/api/proxy/inscope-resources'
       changeOrigin: true
       secure: false
       credentials: dangerously-allow-unauthenticated

--- a/plugins/visual-qontract/package.json
+++ b/plugins/visual-qontract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-visual-qontract",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/visual-qontract/src/components/ChangelogComponent/ChangelogComponent.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogComponent/ChangelogComponent.tsx
@@ -11,10 +11,10 @@ import { MergeQueueTable } from '../MergeQueues/MergeQueueTable';
 export function ChangelogComponent() {
   return (
     <Page themeId="tool">
-      <Header title="App Interface" subtitle="App Interface Change History and Merge Queues"/>
+      <Header title="App Interface" subtitle="App Interface Change History and Merge Queues" />
       <TabbedLayout>
         <TabbedLayout.Route path="/changelog" title="Changelog">
-            <ChangelogFetchComponent />
+          <ChangelogFetchComponent />
         </TabbedLayout.Route>
         <TabbedLayout.Route path="/self-serviceable" title="Self Service Queue">
           <QueueTable
@@ -31,7 +31,7 @@ export function ChangelogComponent() {
           />
         </TabbedLayout.Route>
         <TabbedLayout.Route path="/merge-queue" title="Merge Queue">
-          <MergeQueueTable/>
+          <MergeQueueTable />
         </TabbedLayout.Route>
       </TabbedLayout>
     </Page>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { FormControlLabel, FormGroup, Grid, Paper, Typography } from '@material-ui/core';
+import { Grid, Paper, Typography } from '@material-ui/core';
 import { Table } from '@backstage/core-components';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ChangeTableProps } from './ChangeTypes';
 import { ColumnDefinitions } from './ColumnDefinitions';
 import { SearchBox } from './SearchBox';
 import { FilterManager } from './FilterManager';
-import { Switch } from '@material-ui/core';
 
 export const ChangeTable = ({ changes }: ChangeTableProps) => {
   const [filters, setFilters] = useState<{ field: string; value: string }[]>(
@@ -17,6 +16,7 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
   const [endDate, setEndDate] = useState('');
   const [endTime, setEndTime] = useState('');
   const [searchText, setSearchText] = useState('');
+  const [showUtcTimestamps, setShowUtcTimestamps] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -94,6 +94,8 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       ),
     )
     .filter(change => {
+      // If the start and end dates are not specified,
+      // filter out no changelogs
       if (!startDate && !endDate) {
         return true;
       }
@@ -102,14 +104,14 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       //debugger
       const changeDate = new Date(change.merged_at);
 
+      // Date picker component emits datetime in YYYY-MM-DD format
+      // by default; to maintain the proper locale, convert this datetime
+      // format to MM-DD-YYYY
       const [startYear, startMonth, startDay] = startDate.split("-");
       const [endYear, endMonth, endDay] = endDate.split("-");
 
-      //const start = startDate ? new Date(startDate) : null;
-      //const end = endDate ? new Date(endDate) : null;
-
       const start = new Date(`${startMonth}/${startDay}/${startYear}`);
-      const end = new Date(`${endMonth}/-${endDay}/${endYear}`);
+      const end = new Date(`${endMonth}/${endDay}/${endYear}`);
 
       const [startHour, startMinute] = startTime.split(":").map(Number);
       const [endHour, endMinute] = endTime.split(":").map(Number);
@@ -128,14 +130,7 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
         end.setHours(23, 59);
       }
 
-      // Check if the change date is within the range
-      //const isWithinRange =
-      //  (!start || changeDate >= start) && (!end || changeDate <= end);
-
-      const isWithinRange = changeDate >= start && changeDate <= end;
-      console.log(changeDate, start, end);
-
-      return isWithinRange;
+      return changeDate >= start && changeDate <= end;
     })
     .filter(change =>
       searchText
@@ -173,16 +168,12 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 endTime={endTime}
                 setEndTime={setEndTime}
                 setEndDate={setEndDate}
+                setShowUtcTimestamps={setShowUtcTimestamps}
               />
-            </Grid>
-            <Grid item>
-              <FormGroup>
-                <FormControlLabel control={<Switch />} label="UTC" />
-              </FormGroup>
             </Grid>
           </Grid>
         </Paper>
-      </Grid>
+      </Grid >
       <Grid item xs={9}>
         <Table
           title="Changelog"
@@ -191,6 +182,6 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
           data={filteredData}
         />
       </Grid>
-    </Grid>
+    </Grid >
   );
 };

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -56,6 +56,10 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
 
     if (startDate) {
       queryParams.set('startDate', startDate);
+
+      if (!startTime) {
+        setStartTime("00:00");
+      }
     } else {
       queryParams.delete('startDate');
     }
@@ -68,17 +72,19 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
 
     if (endDate) {
       queryParams.set('endDate', endDate);
+
+      if (!endTime) {
+        setEndTime("23:59");
+      }
     } else {
       queryParams.delete('endDate');
     }
 
     if (endTime) {
-      queryParams.set('endTime', startTime);
+      queryParams.set('endTime', endTime);
     } else {
       queryParams.delete('endTime');
     }
-
-    queryParams.set('utc', String(showUtcTimestamps));
 
     navigate({ search: queryParams.toString() }, { replace: true });
   }, [filters, startDate, startTime, endDate, endTime, showUtcTimestamps, navigate, location.search]);

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -12,7 +12,9 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
     [],
   );
   const [startDate, setStartDate] = useState('');
+  const [startTime, setStartTime] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [endTime, setEndTime] = useState('');
   const [searchText, setSearchText] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
@@ -90,10 +92,10 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
     .filter(change =>
       searchText
         ? Object.values(change).some(value =>
-            Array.isArray(value)
-              ? value.join(' ').toLowerCase().includes(searchText.toLowerCase())
-              : String(value).toLowerCase().includes(searchText.toLowerCase()),
-          )
+          Array.isArray(value)
+            ? value.join(' ').toLowerCase().includes(searchText.toLowerCase())
+            : String(value).toLowerCase().includes(searchText.toLowerCase()),
+        )
         : true,
     );
 
@@ -116,8 +118,12 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 filters={filters}
                 setFilters={setFilters}
                 startDate={startDate}
+                startTime={startTime}
                 setStartDate={setStartDate}
+                setStartTime={setStartTime}
                 endDate={endDate}
+                endTime={endTime}
+                setEndTime={setEndTime}
                 setEndDate={setEndDate}
               />
             </Grid>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { Grid, Paper, Typography } from '@material-ui/core';
+import { FormControlLabel, FormGroup, Grid, Paper, Typography } from '@material-ui/core';
 import { Table } from '@backstage/core-components';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ChangeTableProps } from './ChangeTypes';
 import { ColumnDefinitions } from './ColumnDefinitions';
 import { SearchBox } from './SearchBox';
 import { FilterManager } from './FilterManager';
+import { Switch } from '@material-ui/core';
 
 export const ChangeTable = ({ changes }: ChangeTableProps) => {
   const [filters, setFilters] = useState<{ field: string; value: string }[]>(
@@ -173,6 +174,11 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 setEndTime={setEndTime}
                 setEndDate={setEndDate}
               />
+            </Grid>
+            <Grid item>
+              <FormGroup>
+                <FormControlLabel control={<Switch />} label="UTC" />
+              </FormGroup>
             </Grid>
           </Grid>
         </Paper>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Grid, Paper, Typography } from '@material-ui/core';
+import { Button, Grid, Paper, Typography } from '@material-ui/core';
 import { Table } from '@backstage/core-components';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ChangeTableProps } from './ChangeTypes';
@@ -78,8 +78,10 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       queryParams.delete('endTime');
     }
 
+    queryParams.set('utc', String(showUtcTimestamps));
+
     navigate({ search: queryParams.toString() }, { replace: true });
-  }, [filters, startDate, startTime, endDate, endTime, navigate, location.search]);
+  }, [filters, startDate, startTime, endDate, endTime, showUtcTimestamps, navigate, location.search]);
 
   const addFilter = (field: string, value: string) => {
     setFilters(prevFilters => [...prevFilters, { field, value }]);
@@ -176,9 +178,25 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       </Grid >
       <Grid item xs={9}>
         <Table
-          title="Changelog"
+          title={
+            <>
+              <Typography variant="h5" component="h2">Changelog</Typography>
+              <Grid style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                height: '100%',
+                display: 'flex',
+                marginRight: "20px"
+              }}
+                justifyContent="center" alignItems="center" xs={2}>
+                <Button variant={showUtcTimestamps ? "text" : "contained"} onClick={() => setShowUtcTimestamps(!showUtcTimestamps)}>Local</Button>
+                <Button variant={showUtcTimestamps ? "contained" : "text"} onClick={() => setShowUtcTimestamps(!showUtcTimestamps)}>UTC</Button>
+              </Grid>
+            </>
+          }
           options={{ search: false, paging: true, pageSize: 10 }}
-          columns={ColumnDefinitions(addFilter)}
+          columns={ColumnDefinitions(addFilter, showUtcTimestamps)}
           data={filteredData}
         />
       </Grid>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -176,7 +176,6 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 endTime={endTime}
                 setEndTime={setEndTime}
                 setEndDate={setEndDate}
-                setShowUtcTimestamps={setShowUtcTimestamps}
               />
             </Grid>
           </Grid>
@@ -196,8 +195,8 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 marginRight: "20px"
               }}
                 justifyContent="center" alignItems="center" xs={2}>
-                <Button variant={showUtcTimestamps ? "text" : "contained"} onClick={() => setShowUtcTimestamps(!showUtcTimestamps)}>Local</Button>
-                <Button variant={showUtcTimestamps ? "contained" : "text"} onClick={() => setShowUtcTimestamps(!showUtcTimestamps)}>UTC</Button>
+                <Button variant={showUtcTimestamps ? "text" : "contained"} onClick={() => setShowUtcTimestamps(false)}>Local</Button>
+                <Button variant={showUtcTimestamps ? "contained" : "text"} onClick={() => setShowUtcTimestamps(true)}>UTC</Button>
               </Grid>
             </>
           }

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
@@ -99,8 +99,8 @@ describe('DenseTable component', () => {
     );
 
     // Set date range to only show items from Oct 26, 2024
-    const startDateInput = screen.getByLabelText('Start Date');
-    const endDateInput = screen.getByLabelText('End Date');
+    const startDateInput = screen.getByLabelText(/Start Date/i);
+    const endDateInput = screen.getByLabelText(/End Date/i);
     fireEvent.change(startDateInput, { target: { value: '2024-10-25' } });
     fireEvent.change(endDateInput, { target: { value: '2024-10-27' } });
 

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
@@ -4,22 +4,72 @@ import '@testing-library/jest-dom';
 import { ChangeTable } from './ChangeTable';
 import { MemoryRouter } from 'react-router-dom';
 
-// Sample data for testing
-const testData = [
+const mockChangelogData = [
   {
-    commit: 'abc123',
-    merged_at: '2024-10-21T16:14:25.653Z',
-    change_types: ['Update', 'Bugfix'],
+    commit: "CHANGELOG_DATA_1",
+    merged_at: "2025-01-01T06:25:11.197Z",
+    change_types: [
+      "saas-file-promotion",
+      "progressive-delivery"
+    ],
     error: false,
-    apps: ['App1', 'App2'],
+    apps: ["App1", "App2"]
   },
   {
-    commit: 'def456',
-    merged_at: '2024-10-26T12:30:10.123Z',
-    change_types: ['Feature'],
-    error: true,
-    apps: ['App3'],
+    commit: "CHANGELOG_DATA_2",
+    merged_at: "2025-01-01T08:16:31.588Z",
+    change_types: [
+      "user-updates"
+    ],
+    error: false,
+    apps: ["App1", "App2"]
   },
+  {
+    commit: "CHANGELOG_DATA_3",
+    merged_at: "2025-01-02T00:38:11.670Z",
+    change_types: [
+      "docs"
+    ],
+    error: false,
+    apps: ["App2"]
+  },
+  {
+    commit: "CHANGELOG_DATA_4",
+    merged_at: "2025-01-02T01:55:20.475Z",
+    change_types: [
+      "app-metadata"
+    ],
+    error: false,
+    apps: ["App1", "App2", "App3"]
+  },
+  {
+    commit: "CHANGELOG_DATA_5",
+    merged_at: "2025-01-02T07:26:33.912Z",
+    change_types: [
+      "resource-updates"
+    ],
+    error: false,
+    apps: ["App1", "App3"]
+  },
+  {
+    commit: "CHANGELOG_DATA_6",
+    merged_at: "2025-01-03T15:13:46.076Z",
+    change_types: [
+      "cluster-upgrade"
+    ],
+    error: false,
+    apps: ["App1"]
+  },
+  {
+    commit: "CHANGELOG_DATA_7",
+    merged_at: "2025-01-03T16:20:57.323Z",
+    change_types: [
+      "Quarkus",
+      "dev-file-registry"
+    ],
+    error: false,
+    apps: ["App2", "App4"]
+  }
 ];
 
 // Mock useNavigate once at the module level
@@ -29,7 +79,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => navigateMock, // Return the mock function
 }));
 
-describe('DenseTable component', () => {
+describe('ChangelogFetch component', () => {
   beforeEach(() => {
     jest.clearAllMocks(); // Reset the mock before each test
   });
@@ -37,7 +87,7 @@ describe('DenseTable component', () => {
   it('renders the table with correct columns and rows', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
@@ -46,25 +96,48 @@ describe('DenseTable component', () => {
     expect(screen.getByText('Merged At')).toBeInTheDocument();
     expect(screen.getByText('Change Types')).toBeInTheDocument();
     expect(screen.getByText('Apps')).toBeInTheDocument();
+  });
+
+  it('renders the specified logs for a given date range', () => {
+    render(
+      <MemoryRouter>
+        <ChangeTable changes={mockChangelogData} />
+      </MemoryRouter>,
+    );
 
     // Check if commit links are correct
-    const commitLink = screen.getByText('abc123');
+    const commitLink = screen.getByText('CHANGELOG_DATA_1');
     expect(commitLink).toHaveAttribute(
       'href',
-      'https://gitlab.cee.redhat.com/service/app-interface/-/commit/abc123',
+      'https://gitlab.cee.redhat.com/service/app-interface/-/commit/CHANGELOG_DATA_1',
     );
     expect(commitLink).toHaveStyle('text-decoration: underline');
     expect(commitLink).toHaveStyle('color: #007bff');
+  });
 
-    // Check for date presence with regex to handle different formats
-    expect(screen.getByText(/Oct 21,? 2024/)).toBeInTheDocument();
-    expect(screen.getByText(/Oct 26,? 2024/)).toBeInTheDocument();
+  it('renders the timestamp for the changelog in UTC and local time format', () => {
+    render(
+      <MemoryRouter>
+        <ChangeTable changes={mockChangelogData} />
+      </MemoryRouter>,
+    );
+
+    const utcButton = screen.getByText("UTC");
+    const localButton = screen.getByText("Local");
+
+    // Verify UTC time format toggle works
+    fireEvent.click(utcButton);
+    expect(screen.getByText("2025-01-01T06:25:11.197Z")).toBeInTheDocument();
+
+    // Verify local time format toggle works
+    fireEvent.click(localButton);
+    expect(screen.getByText("Jan 1, 2025, 6:25:11 AM UTC")).toBeInTheDocument();
   });
 
   it('shows instructional text when no filters are applied', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
@@ -77,7 +150,7 @@ describe('DenseTable component', () => {
   it('conditionally displays "Clear Filters" button when filters or dates are active', () => {
     render(
       <MemoryRouter initialEntries={['/?filters=type%3AUpdate']}>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
@@ -91,28 +164,55 @@ describe('DenseTable component', () => {
     expect(screen.queryByTestId('clear-all-filters')).not.toBeInTheDocument();
   });
 
-  it('filters data by date range', () => {
+  it('filters changelog entries by date', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
-    // Set date range to only show items from Oct 26, 2024
     const startDateInput = screen.getByLabelText(/Start Date/i);
     const endDateInput = screen.getByLabelText(/End Date/i);
-    fireEvent.change(startDateInput, { target: { value: '2024-10-25' } });
-    fireEvent.change(endDateInput, { target: { value: '2024-10-27' } });
 
-    // Verify that only the relevant row is displayed
-    expect(screen.queryByText('abc123')).not.toBeInTheDocument();
-    expect(screen.getByText('def456')).toBeInTheDocument();
+    fireEvent.change(startDateInput, { target: { value: '2025-01-01' } });
+    fireEvent.change(endDateInput, { target: { value: '2025-01-01' } });
+
+    expect(screen.queryByText('CHANGELOG_DATA_1')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_2')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_3')).not.toBeInTheDocument();
+  });
+
+  it('filters changelog data via both date and time', () => {
+    render(
+      <MemoryRouter>
+        <ChangeTable changes={mockChangelogData} />
+      </MemoryRouter>,
+    );
+
+    const startDateInput = screen.getByLabelText(/Start Date/i);
+    const endDateInput = screen.getByLabelText(/End Date/i);
+
+    const startTimeInput = screen.getByLabelText(/Start Time/i);
+    const endTimeInput = screen.getByLabelText(/End Time/i);
+
+    fireEvent.change(startDateInput, { target: { value: '2025-01-02' } });
+    fireEvent.change(endDateInput, { target: { value: '2025-01-02' } });
+
+    fireEvent.change(startTimeInput, { target: { value: '00:00' } });
+    fireEvent.change(endTimeInput, { target: { value: '05:00' } });
+
+    expect(screen.queryByText('CHANGELOG_DATA_3')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_4')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_5')).not.toBeInTheDocument();
+
+    fireEvent.change(endTimeInput, { target: { value: '07:30' } });
+    expect(screen.queryByText('CHANGELOG_DATA_5')).toBeInTheDocument();
   });
 
   it('clears the search text when the clear button is clicked', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
@@ -129,7 +229,7 @@ describe('DenseTable component', () => {
   it('removes a filter when the "x" icon is clicked on a filter pill', async () => {
     render(
       <MemoryRouter initialEntries={['/?filters=type%3AUpdate,app%3AApp1']}>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
@@ -161,58 +261,58 @@ describe('DenseTable component', () => {
   it('renders change types and apps as pills with correct styling', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
     // Find the change type pill by its text content
-    const changeTypePill = screen.getByText(/update/i);
+    const changeTypePill = screen.getByText(/progressive-delivery/i);
     expect(changeTypePill).toBeInTheDocument();
 
     // Find the app pill by its text content
-    const appPill = screen.getByText(/app1/i);
+    const appPill = screen.getAllByText(/App1/i)[0];
     expect(appPill).toBeInTheDocument();
   });
 
   it('displays the correct icon for error field', () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
   });
 
   it('loads initial filters from the URL query string', () => {
     render(
-      <MemoryRouter initialEntries={['/?filters=type%3AUpdate,app%3AApp1']}>
-        <ChangeTable changes={testData} />
+      <MemoryRouter initialEntries={['/?filters=type%3Aprogressive-delivery,app%3AApp1']}>
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
     // Check if the initial filters are applied based on the URL
-    expect(screen.getAllByText(/update/i)[1]).toBeInTheDocument(); // Second occurrence for filter pill
-    expect(screen.getAllByText(/app1/i)[1]).toBeInTheDocument(); // Second occurrence for filter pill
+    expect(screen.getAllByText(/progressive-delivery/i)[1]).toBeInTheDocument(); // Second occurrence for filter pill
+    expect(screen.getAllByText(/App1/i)[0]).toBeInTheDocument(); // Second occurrence for filter pill
   });
 
   it('updates the URL with field-based filters when multiple pills are clicked', async () => {
     render(
       <MemoryRouter>
-        <ChangeTable changes={testData} />
+        <ChangeTable changes={mockChangelogData} />
       </MemoryRouter>,
     );
 
     // Simulate clicking on a change type pill to add it as a filter
-    const changeTypePill = screen.getAllByText(/update/i)[0];
+    const changeTypePill = screen.getAllByText(/progressive-delivery/i)[0];
     fireEvent.click(changeTypePill);
 
     // Simulate clicking on an app pill to add another field-based filter
-    const appPill = screen.getAllByText(/app1/i)[0];
+    const appPill = screen.getAllByText(/App1/i)[0];
     fireEvent.click(appPill);
 
     // Wait for the navigateMock to be called with the final, full query string
     await waitFor(() =>
       expect(navigateMock).toHaveBeenLastCalledWith(
-        { search: 'filters=type%3AUpdate%2Capp%3AApp1' },
+        { search: 'filters=type%3Aprogressive-delivery%2Capp%3AApp1' },
         { replace: true },
       ),
     );

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ColumnDefinitions.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ColumnDefinitions.tsx
@@ -4,49 +4,53 @@ import { PillList } from './PillList';
 
 export const ColumnDefinitions = (
   addFilter: (field: string, value: string) => void,
+  showUtcTimestamps: boolean
 ): TableColumn[] => [
-  {
-    title: 'Commit',
-    field: 'commit',
-    render: rowData => (
-      <a
-        href={`https://gitlab.cee.redhat.com/service/app-interface/-/commit/${rowData.commit}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: '#007bff', textDecoration: 'underline' }}
-      >
-        {rowData.description || rowData.commit}
-      </a>
-    ),
-  },
-  {
-    title: 'Merged At',
-    field: 'merged_at',
-    render: rowData => {
-      const date = new Date(rowData.merged_at);
-      return new Intl.DateTimeFormat('default', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-        timeZoneName: 'short',
-      }).format(date);
+    {
+      title: 'Commit',
+      field: 'commit',
+      render: rowData => (
+        <a
+          href={`https://gitlab.cee.redhat.com/service/app-interface/-/commit/${rowData.commit}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: '#007bff', textDecoration: 'underline' }}
+        >
+          {rowData.description || rowData.commit}
+        </a>
+      ),
     },
-  },
-  {
-    title: 'Change Types',
-    field: 'change_types',
-    render: rowData => (
-      <PillList items={rowData.change_types} field="type" onClick={addFilter} />
-    ),
-  },
-  {
-    title: 'Apps',
-    field: 'apps',
-    render: rowData => (
-      <PillList items={rowData.apps} field="app" onClick={addFilter} />
-    ),
-  },
-];
+    {
+      title: 'Merged At',
+      field: 'merged_at',
+      render: rowData => {
+        if (showUtcTimestamps) {
+          return rowData.merged_at
+        }
+        const date = new Date(rowData.merged_at);
+        return new Intl.DateTimeFormat('default', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+          second: 'numeric',
+          timeZoneName: 'short',
+        }).format(date);
+      },
+    },
+    {
+      title: 'Change Types',
+      field: 'change_types',
+      render: rowData => (
+        <PillList items={rowData.change_types} field="type" onClick={addFilter} />
+      ),
+    },
+    {
+      title: 'Apps',
+      field: 'apps',
+      render: rowData => (
+        <PillList items={rowData.apps} field="app" onClick={addFilter} />
+      ),
+    },
+  ];

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
@@ -15,7 +15,8 @@ export const FilterManager = ({
   endDate,
   setEndDate,
   endTime,
-  setEndTime
+  setEndTime,
+  setShowUtcTimestamps
 }) => {
   const clearAllFilters = () => {
     setFilters([]);
@@ -23,6 +24,7 @@ export const FilterManager = ({
     setStartTime('');
     setEndDate('');
     setEndTime('');
+    setShowUtcTimestamps(false);
   };
 
   const removeFilter = (filter: Filter) => {

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
@@ -15,8 +15,7 @@ export const FilterManager = ({
   endDate,
   setEndDate,
   endTime,
-  setEndTime,
-  setShowUtcTimestamps
+  setEndTime
 }) => {
   const clearAllFilters = () => {
     setFilters([]);
@@ -24,7 +23,6 @@ export const FilterManager = ({
     setStartTime('');
     setEndDate('');
     setEndTime('');
-    setShowUtcTimestamps(false);
   };
 
   const removeFilter = (filter: Filter) => {

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
@@ -20,7 +20,9 @@ export const FilterManager = ({
   const clearAllFilters = () => {
     setFilters([]);
     setStartDate('');
+    setStartTime('');
     setEndDate('');
+    setEndTime('');
   };
 
   const removeFilter = (filter: Filter) => {
@@ -48,6 +50,7 @@ export const FilterManager = ({
           <TextField
             id="start-date"
             fullWidth
+            required
             label="Start Date"
             type="date"
             value={startDate}
@@ -70,6 +73,7 @@ export const FilterManager = ({
           <TextField
             id="end-date"
             fullWidth
+            required
             label="End Date"
             type="date"
             value={endDate}

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
@@ -10,8 +10,12 @@ export const FilterManager = ({
   setFilters,
   startDate,
   setStartDate,
+  startTime,
+  setStartTime,
   endDate,
   setEndDate,
+  endTime,
+  setEndTime
 }) => {
   const clearAllFilters = () => {
     setFilters([]);
@@ -53,12 +57,34 @@ export const FilterManager = ({
         </Grid>
         <Grid item xs={12}>
           <TextField
+            id="start-time"
+            fullWidth
+            label="Start Time"
+            type="time"
+            value={startTime}
+            onChange={e => setStartTime(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
             id="end-date"
             fullWidth
             label="End Date"
             type="date"
             value={endDate}
             onChange={e => setEndDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            id="end-time"
+            fullWidth
+            label="End Time"
+            type="time"
+            value={endTime}
+            onChange={e => setEndTime(e.target.value)}
             InputLabelProps={{ shrink: true }}
           />
         </Grid>


### PR DESCRIPTION
### Change Details
- Updated `README.md` to add instructions for running locally
  - Included instructions for running Podman container, pulling from Quay
  - Refactored `inscope-resources` endpoint target to use env var
- Updated `app-config.yaml` to use Inscope resources env var
- Implementing start/end time filtering logic and local/UTC time format toggling in `ChangeTable.tsx`
- Updating time formatting in `ColumnDefinitions.tsx`
- Refactoring `ChangelogFetchComponent` test to use regex search