### PR TITLE
Implementing start of UTC filtering table logic

### DIFF
--- a/plugins/visual-qontract/package.json
+++ b/plugins/visual-qontract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-visual-qontract",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/visual-qontract/package.json
+++ b/plugins/visual-qontract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-visual-qontract",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -12,13 +12,45 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
     [],
   );
   const [startDate, setStartDate] = useState('');
+  const [utcStartDate, setUtcStartDate] = useState('');
   const [startTime, setStartTime] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [utcEndDate, setUtcEndDate] = useState('');
   const [endTime, setEndTime] = useState('');
   const [searchText, setSearchText] = useState('');
   const [showUtcTimestamps, setShowUtcTimestamps] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+
+  function retrieveFilteringBounds() {
+    // Date picker component emits datetime in YYYY-MM-DD format
+    // by default; to maintain the proper locale, convert this datetime
+    // format to MM-DD-YYYY
+    const [startYear, startMonth, startDay] = startDate.split("-");
+    const [endYear, endMonth, endDay] = endDate.split("-");
+
+    const start = new Date(`${startMonth}/${startDay}/${startYear}`);
+    const end = new Date(`${endMonth}/${endDay}/${endYear}`);
+
+    const [startHour, startMinute] = startTime.split(":").map(Number);
+    const [endHour, endMinute] = endTime.split(":").map(Number);
+
+    if (startTime) {
+      start.setHours(startHour, startMinute);
+    }
+    else {
+      start.setHours(0, 0);
+    }
+
+    if (endTime) {
+      end.setHours(endHour, endMinute);
+    }
+    else {
+      end.setHours(23, 59);
+    }
+
+    return { start, end };
+  }
 
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search);
@@ -87,7 +119,20 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
     }
 
     navigate({ search: queryParams.toString() }, { replace: true });
-  }, [filters, startDate, startTime, endDate, endTime, showUtcTimestamps, navigate, location.search]);
+  }, [filters, startDate, startTime, endDate, endTime, navigate, location.search]);
+
+  useEffect(() => {
+    if (!startDate && !endDate) {
+      return;
+    }
+
+    if (showUtcTimestamps) {
+      const { start, end } = retrieveFilteringBounds();
+
+      setUtcStartDate(start.toISOString());
+      setUtcEndDate(end.toISOString());
+    }
+  }, [showUtcTimestamps])
 
   const addFilter = (field: string, value: string) => {
     setFilters(prevFilters => [...prevFilters, { field, value }]);
@@ -102,6 +147,18 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       ),
     )
     .filter(change => {
+      if (showUtcTimestamps) {
+        if (!utcStartDate && !utcEndDate) {
+          return true;
+        }
+
+        // Convert the change's date and the filter dates to Date objects
+        //debugger
+        const changeDate = new Date(change.merged_at);
+
+        return changeDate >= new Date(utcStartDate) && changeDate <= new Date(utcEndDate);
+      }
+
       // If the start and end dates are not specified,
       // filter out no changelogs
       if (!startDate && !endDate) {
@@ -111,33 +168,7 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       // Convert the change's date and the filter dates to Date objects
       //debugger
       const changeDate = new Date(change.merged_at);
-
-      // Date picker component emits datetime in YYYY-MM-DD format
-      // by default; to maintain the proper locale, convert this datetime
-      // format to MM-DD-YYYY
-      const [startYear, startMonth, startDay] = startDate.split("-");
-      const [endYear, endMonth, endDay] = endDate.split("-");
-
-      const start = new Date(`${startMonth}/${startDay}/${startYear}`);
-      const end = new Date(`${endMonth}/${endDay}/${endYear}`);
-
-      const [startHour, startMinute] = startTime.split(":").map(Number);
-      const [endHour, endMinute] = endTime.split(":").map(Number);
-
-      if (startTime) {
-        start.setHours(startHour, startMinute);
-      }
-      else {
-        start.setHours(0, 0);
-      }
-
-      if (endTime) {
-        end.setHours(endHour, endMinute);
-      }
-      else {
-        end.setHours(23, 59);
-      }
-
+      const { start, end } = retrieveFilteringBounds();
       return changeDate >= start && changeDate <= end;
     })
     .filter(change =>
@@ -169,13 +200,18 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
                 filters={filters}
                 setFilters={setFilters}
                 startDate={startDate}
+                utcStartDate={utcStartDate}
                 startTime={startTime}
                 setStartDate={setStartDate}
+                setUtcStartDate={setUtcStartDate}
                 setStartTime={setStartTime}
                 endDate={endDate}
+                utcEndDate={utcEndDate}
                 endTime={endTime}
                 setEndTime={setEndTime}
                 setEndDate={setEndDate}
+                setUtcEndDate={setUtcEndDate}
+                showUtcTimestamps={showUtcTimestamps}
               />
             </Grid>
           </Grid>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangeTable.tsx
@@ -96,6 +96,25 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       queryParams.delete('startDate');
     }
 
+    if (utcStartDate) {
+      const utcDate = new Date(utcStartDate);
+
+      // If the entered UTC start date is invalid, do not update
+      // the local start date field or the associated
+      // search parameters
+      if (!isNaN(utcDate.getTime())) {
+        const formattedDate = `${utcDate.getFullYear()}-${String(utcDate.getMonth() + 1).padStart(2, '0')}-${String(utcDate.getDate()).padStart(2, '0')}`;
+        const formattedTime = `${String(utcDate.getHours()).padStart(2, '0')}:${String(utcDate.getMinutes()).padStart(2, '0')}`;
+
+        setStartDate(formattedDate);
+        setStartTime(formattedTime);
+      }
+    }
+    else {
+      queryParams.delete('startDate');
+      queryParams.delete('startTime');
+    }
+
     if (startTime) {
       queryParams.set('startTime', startTime);
     } else {
@@ -112,6 +131,27 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
       queryParams.delete('endDate');
     }
 
+    if (utcEndDate) {
+      const utcDate = new Date(utcEndDate);
+
+      // If the entered UTC end date is invalid, do not
+      // update the local end date field oe the associated
+      // search parameters
+      if (!isNaN(utcDate.getTime())) {
+
+        const formattedDate = `${utcDate.getFullYear()}-${String(utcDate.getMonth() + 1).padStart(2, '0')}-${String(utcDate.getDate()).padStart(2, '0')}`;
+        const formattedTime = `${String(utcDate.getHours()).padStart(2, '0')}:${String(utcDate.getMinutes()).padStart(2, '0')}`;
+
+        setEndDate(formattedDate);
+        setEndTime(formattedTime);
+      }
+    }
+    else {
+      queryParams.delete('endDate');
+      queryParams.delete('endTime');
+    }
+
+
     if (endTime) {
       queryParams.set('endTime', endTime);
     } else {
@@ -119,7 +159,7 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
     }
 
     navigate({ search: queryParams.toString() }, { replace: true });
-  }, [filters, startDate, startTime, endDate, endTime, navigate, location.search]);
+  }, [filters, startDate, utcStartDate, startTime, endDate, utcEndDate, endTime, navigate, location.search]);
 
   useEffect(() => {
     if (!startDate && !endDate) {
@@ -152,10 +192,7 @@ export const ChangeTable = ({ changes }: ChangeTableProps) => {
           return true;
         }
 
-        // Convert the change's date and the filter dates to Date objects
-        //debugger
         const changeDate = new Date(change.merged_at);
-
         return changeDate >= new Date(utcStartDate) && changeDate <= new Date(utcEndDate);
       }
 

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
@@ -154,8 +154,8 @@ describe('ChangelogFetch component', () => {
 
     // Start and end fields should have HTML5 date
     // input types
-    expect(startDateInput.getAttribute("type")).toBe("date");
-    expect(endDateInput.getAttribute("type")).toBe("date");
+    expect(startDateInput).toHaveAttribute("type", "date");
+    expect(endDateInput).toHaveAttribute("type", "date");
 
     // Toggle on UTC mode
     const utcButton = screen.getByText("UTC");
@@ -170,8 +170,8 @@ describe('ChangelogFetch component', () => {
 
     // Start and end fields should have default text
     // input types
-    expect(startDateInput.getAttribute("type")).toBe("text");
-    expect(endDateInput.getAttribute("type")).toBe("text");
+    expect(startDateInput).toHaveAttribute("type", "text");
+    expect(endDateInput).toHaveAttribute("type", "text");
 
     const localButton = screen.getByText("Local");
     fireEvent.click(localButton);
@@ -181,8 +181,8 @@ describe('ChangelogFetch component', () => {
 
     // Start and end fields should revert back to
     // HTML5 date input types
-    expect(startDateInput.getAttribute("type")).toBe("date");
-    expect(endDateInput.getAttribute("type")).toBe("date");
+    expect(startDateInput).toHaveAttribute("type", "date");
+    expect(endDateInput).toHaveAttribute("type", "date");
 
     // Start and end time fields should reppear on screen
     expect(screen.queryByText(/Start Time/)).toBeInTheDocument();
@@ -205,7 +205,7 @@ describe('ChangelogFetch component', () => {
     startDateInput = screen.getByLabelText(/Start Date/i);
     endDateInput = screen.getByLabelText(/End Date/i);
 
-    fireEvent.change(startDateInput, { target: { value: "2025-01-01T04:30:00.000Z" } });
+    fireEvent.change(startDateInput, { target: { value: "2025-01-01T06:00:00.000Z" } });
     fireEvent.change(endDateInput, { target: { value: "2025-01-02T01:30:00.000Z" } });
 
     expect(screen.queryByText('CHANGELOG_DATA_1')).toBeInTheDocument();
@@ -225,14 +225,8 @@ describe('ChangelogFetch component', () => {
     startDateInput = screen.getByLabelText(/Start Date/i);
     endDateInput = screen.getByLabelText(/End Date/i);
 
-    const startTimeInput = screen.getByLabelText(/Start Time/);
-    const endTimeInput = screen.getByLabelText(/End Time/);
-
-    expect(startDateInput.getAttribute("value")).toBe("2025-01-01");
-    expect(endDateInput.getAttribute("value")).toBe("2025-01-01");
-
-    expect(startTimeInput.getAttribute("value")).toBe("00:30");
-    expect(endTimeInput.getAttribute("value")).toBe("21:30");
+    expect(startDateInput).toHaveValue("2025-01-01");
+    expect(endDateInput).toHaveValue("2025-01-02");
   });
 
   it('shows instructional text when no filters are applied', () => {

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/ChangelogFetchComponent.test.tsx
@@ -134,6 +134,107 @@ describe('ChangelogFetch component', () => {
     expect(screen.getByText("Jan 1, 2025, 6:25:11 AM UTC")).toBeInTheDocument();
   });
 
+  it('should hide time filtering fields and update date filtering fields to text inputs when UTC mode is enabled', () => {
+    render(
+      <MemoryRouter>
+        <ChangeTable changes={mockChangelogData} />
+      </MemoryRouter>,
+    );
+
+    let startDateInput;
+    let endDateInput;
+
+    startDateInput = screen.getByLabelText(/Start Date/i);
+    endDateInput = screen.getByLabelText(/End Date/i);
+
+    // Start and end time inputs should be displayed
+    // on the screen by default
+    expect(screen.queryByText(/Start Time/)).toBeInTheDocument();
+    expect(screen.queryByText(/End Time/)).toBeInTheDocument();
+
+    // Start and end fields should have HTML5 date
+    // input types
+    expect(startDateInput.getAttribute("type")).toBe("date");
+    expect(endDateInput.getAttribute("type")).toBe("date");
+
+    // Toggle on UTC mode
+    const utcButton = screen.getByText("UTC");
+    fireEvent.click(utcButton);
+
+    // Start and end date inputs should be hidden
+    expect(screen.queryByText(/Start Time/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/End Time/)).not.toBeInTheDocument();
+
+    startDateInput = screen.getByLabelText(/Start Date/i);
+    endDateInput = screen.getByLabelText(/End Date/i);
+
+    // Start and end fields should have default text
+    // input types
+    expect(startDateInput.getAttribute("type")).toBe("text");
+    expect(endDateInput.getAttribute("type")).toBe("text");
+
+    const localButton = screen.getByText("Local");
+    fireEvent.click(localButton);
+
+    startDateInput = screen.getByLabelText(/Start Date/i);
+    endDateInput = screen.getByLabelText(/End Date/i);
+
+    // Start and end fields should revert back to
+    // HTML5 date input types
+    expect(startDateInput.getAttribute("type")).toBe("date");
+    expect(endDateInput.getAttribute("type")).toBe("date");
+
+    // Start and end time fields should reppear on screen
+    expect(screen.queryByText(/Start Time/)).toBeInTheDocument();
+    expect(screen.queryByText(/End Time/)).toBeInTheDocument();
+  });
+
+  it('should filter changelog entries in UTC mode', () => {
+    render(
+      <MemoryRouter>
+        <ChangeTable changes={mockChangelogData} />
+      </MemoryRouter>,
+    );
+
+    const utcButton = screen.getByText("UTC");
+    fireEvent.click(utcButton);
+
+    let startDateInput;
+    let endDateInput;
+
+    startDateInput = screen.getByLabelText(/Start Date/i);
+    endDateInput = screen.getByLabelText(/End Date/i);
+
+    fireEvent.change(startDateInput, { target: { value: "2025-01-01T04:30:00.000Z" } });
+    fireEvent.change(endDateInput, { target: { value: "2025-01-02T01:30:00.000Z" } });
+
+    expect(screen.queryByText('CHANGELOG_DATA_1')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_2')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_3')).toBeInTheDocument();
+    expect(screen.queryByText('CHANGELOG_DATA_4')).not.toBeInTheDocument();
+
+    fireEvent.change(endDateInput, { target: { value: "2025-01-02T05:00:00.000Z" } });
+    expect(screen.queryByText('CHANGELOG_DATA_4')).toBeInTheDocument();
+
+    // When switching to local mode from UTC mode, the datetime
+    // data should persist and be displayed in the start/end
+    // date and start/end time fields
+    const localButton = screen.getByText("Local");
+    fireEvent.click(localButton);
+
+    startDateInput = screen.getByLabelText(/Start Date/i);
+    endDateInput = screen.getByLabelText(/End Date/i);
+
+    const startTimeInput = screen.getByLabelText(/Start Time/);
+    const endTimeInput = screen.getByLabelText(/End Time/);
+
+    expect(startDateInput.getAttribute("value")).toBe("2025-01-01");
+    expect(endDateInput.getAttribute("value")).toBe("2025-01-01");
+
+    expect(startTimeInput.getAttribute("value")).toBe("00:30");
+    expect(endTimeInput.getAttribute("value")).toBe("21:30");
+  });
+
   it('shows instructional text when no filters are applied', () => {
     render(
       <MemoryRouter>

--- a/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
+++ b/plugins/visual-qontract/src/components/ChangelogFetchComponent/FilterManager.tsx
@@ -10,18 +10,25 @@ export const FilterManager = ({
   setFilters,
   startDate,
   setStartDate,
+  utcStartDate,
+  setUtcStartDate,
   startTime,
   setStartTime,
   endDate,
   setEndDate,
+  utcEndDate,
+  setUtcEndDate,
   endTime,
-  setEndTime
+  setEndTime,
+  showUtcTimestamps
 }) => {
   const clearAllFilters = () => {
     setFilters([]);
     setStartDate('');
+    setUtcStartDate('');
     setStartTime('');
     setEndDate('');
+    setUtcEndDate('');
     setEndTime('');
   };
 
@@ -46,52 +53,84 @@ export const FilterManager = ({
         )}
       </Box>
       <Grid container spacing={2}>
-        <Grid item xs={12}>
-          <TextField
-            id="start-date"
-            fullWidth
-            required
-            label="Start Date"
-            type="date"
-            value={startDate}
-            onChange={e => setStartDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            id="start-time"
-            fullWidth
-            label="Start Time"
-            type="time"
-            value={startTime}
-            onChange={e => setStartTime(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            id="end-date"
-            fullWidth
-            required
-            label="End Date"
-            type="date"
-            value={endDate}
-            onChange={e => setEndDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            id="end-time"
-            fullWidth
-            label="End Time"
-            type="time"
-            value={endTime}
-            onChange={e => setEndTime(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-        </Grid>
+        {!showUtcTimestamps &&
+          <>
+            <Grid item xs={12}>
+              <TextField
+                id="start-date"
+                fullWidth
+                required
+                label="Start Date"
+                type="date"
+                value={startDate}
+                onChange={e => setStartDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                id="start-time"
+                fullWidth
+                label="Start Time"
+                type="time"
+                value={startTime}
+                onChange={e => setStartTime(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                id="end-date"
+                fullWidth
+                required
+                label="End Date"
+                type="date"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                id="end-time"
+                fullWidth
+                label="End Time"
+                type="time"
+                value={endTime}
+                onChange={e => setEndTime(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+          </>
+        }
+        {showUtcTimestamps &&
+          <>
+            <Grid item xs={12}>
+              <TextField
+                id="start-date"
+                fullWidth
+                required
+                label="Start Date"
+                type="text"
+                value={utcStartDate}
+                onChange={e => setUtcStartDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                id="end-date"
+                fullWidth
+                required
+                label="End Date"
+                type="text"
+                value={utcEndDate}
+                onChange={e => setUtcEndDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+          </>
+        }
         {filters.length > 0 && (
           <Grid item xs={12}>
             <Typography variant="button">Active Filters</Typography>
@@ -111,6 +150,6 @@ export const FilterManager = ({
           </Grid>
         )}
       </Grid>
-    </Box>
+    </Box >
   );
 };


### PR DESCRIPTION
## Change Details
* Changelog entries can now be searched for using ISO-8601 time formatting when UTC mode is enabled - introduces parity for the time filtering fields under the "Filters" section of the UI and the UTC toggle on the top right
* Adds tests for updated filtering input logic